### PR TITLE
Add evaluation logging helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .env
 .streamlit/secrets.toml
 eval_results.txt
+eval_dataset.csv

--- a/evaluation_logger.py
+++ b/evaluation_logger.py
@@ -1,5 +1,25 @@
 import pandas as pd
 import os
+import json
+
 
 def append_example(prompt: str, response: dict, path: str = "eval_dataset.csv"):
-    pd.DataFrame([]).to_csv(path, mode="a", header=not os.path.exists(path), index=False)
+    """Append a prompt/response pair to a CSV file.
+
+    Parameters
+    ----------
+    prompt : str
+        The user's input prompt.
+    response : dict
+        The structured response returned by the model.
+    path : str, optional
+        CSV path to append to, by default "eval_dataset.csv".
+    """
+
+    row = {
+        "prompt": prompt,
+        "response": json.dumps(response, ensure_ascii=False),
+    }
+    pd.DataFrame([row]).to_csv(
+        path, mode="a", header=not os.path.exists(path), index=False
+    )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -10,6 +10,7 @@ from typing import List
 from google import genai
 from pydantic import BaseModel
 from prompt_templates import build_rag_prompt
+from evaluation_logger import append_example
 
 load_dotenv()
 openaiClient = openai.OpenAI(
@@ -194,6 +195,7 @@ if st.button("Evaluate Response"):
     with st.spinner("Evaluating with AI..."):
         try: 
             result = evaluate_response_with_rag(user_input, lesson, model_choice)
+            append_example(user_input, result)
             print(result)
             
             # Score + Performance


### PR DESCRIPTION
## Summary
- implement `append_example` helper to log prompt/response pairs
- call `append_example` in `streamlit_app.py`
- ignore generated CSV dataset

## Testing
- `python3 -m py_compile evaluation_logger.py streamlit_app.py`